### PR TITLE
Benchmark methods parallel

### DIFF
--- a/test_model.py
+++ b/test_model.py
@@ -39,7 +39,7 @@ def ensure_dir(dir: str) -> Path:
     return path
 
 
-def setup_log_files() -> tuple[dict[str, Path]]:
+def setup_log_files() -> tuple[dict[str, Path], dict[str, Path]]:
     # Setup log directory
     log_dir = ensure_dir("logs")
 
@@ -92,7 +92,7 @@ def safe_err_log(method: str, *args: Any, **kwargs: Any) -> None:
 def aggregate_benchmarks() -> tuple[list[Any], list[Any]]:
     ids, aggregate_prompts = [], []
     for method, prompts in DATASETS.items():
-        aggregate_prompts.extend(prompts)
+        aggregate_prompts.extend(prompts[:N_PROMPTS])
         # (prompt index (1-indexed) in resp. dataset, method string (e.g. "base", "scope", "cot", etc.))
         ids.extend(zip(range(1, N_PROMPTS+1), [method] * N_PROMPTS))
     return ids, aggregate_prompts

--- a/test_model.py
+++ b/test_model.py
@@ -1,6 +1,11 @@
 import re
 import json
+import os
 from openai import OpenAI
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Dict
+from threading import Lock
+from pathlib import Path
 
 # Initialize client
 client = OpenAI(
@@ -11,19 +16,50 @@ client = OpenAI(
 # Load benchmark dataset (with question, answer, cot_prompt)
 with open("benchmark_dataset.json", "r") as f:
     final_benchmark = json.load(f)
-# Collect simplified results
-results = []
 
-for idx,item in enumerate(final_benchmark):
-    print("TURN: ", idx)
+# Useful constants
+N_RETRIES = 2
+N_CORES = os.cpu_count() or 8
+N_WORKERS = N_CORES * 2
+N_PROMPTS = len(final_benchmark)
+
+PROJECT_DIR = Path(__file__).parent
+
+# Responses file
+RESPONSES_FILE = PROJECT_DIR / "model_responses.json"
+
+# Setup log directory/files
+LOG_DIR = PROJECT_DIR / "logs"
+LOG_DIR.mkdir(exist_ok=True, parents=True)
+
+OUT_LOG = LOG_DIR / "model_responses.out"
+ERR_LOG = LOG_DIR / "model_responses.err"
+
+try: # remove log files if they already exist
+    OUT_LOG.unlink()
+    ERR_LOG.unlink()
+except FileNotFoundError:
+    pass
+
+# Lock to prevent interleaving prints
+out_lock, err_lock = Lock(), Lock()
+def safe_out_log(*args: Any, **kwargs: Any) -> None:
+    with out_lock, open(OUT_LOG, "a") as out: # to stdout and out log
+        print(*args, **kwargs)
+        print(*args, **kwargs, file=out)
+
+def safe_err_log(*args: Any, **kwargs: Any) -> None:
+    with err_lock, open(ERR_LOG, "a") as err:
+        print(*args, **kwargs, file=err)
+
+def extract_model_output(idx: int, item: Dict[str, Any]) -> Dict[str, Any]:
     messages = [
         {"role": "system", "content": "You are a helpful math assistant."},
         {"role": "user", "content": item["prompt"]}
     ]
-    
 
-    RETRYS = 0
-    while RETRYS >= 0:
+    retries_left = N_RETRIES
+    while retries_left >= 0:
         try:
             # Call the v1/chat/completions endpoint
             response = client.chat.completions.create(
@@ -32,31 +68,36 @@ for idx,item in enumerate(final_benchmark):
                 temperature=0.0,
                 max_tokens=8000
             )
+            # Extract model output
+            model_output = response.choices[0].message.content
             break  # success → exit loop
         except Exception as e:
-            print(f"Error: {e}")
-            RETRYS -= 1  # decrease retry counter
-            if RETRYS == -1:
-                response = "<answer> response failed </answer>"
+            err_msg = f"[ERROR] Prompt {idx+1}: {e}"
+            retries_left -= 1  # decrease retry counter
+            if retries_left == -1:
+                model_output = "<answer> response failed </answer>"
+                safe_err_log(err_msg, f"Out of retries\n", sep="\n")
                 break
             else:
-                print(f"Retrying... ({RETRYS} left)")
+                safe_err_log(err_msg, f"Retrying... ({retries_left} retries left)\n", sep="\n")
     
-    # Extract model iutput
-    model_output = response.choices[0].message.content
-    print(model_output)
+    safe_out_log(f"Prompt {idx+1}:", model_output, sep="\n", end="\n\n")
 
-    # Append simplified entry
-    results.append({
+    return {
+        # compile simplified result entry
         "category": item["category"],
         "question": item["question"],
         "answer": item["answer"],
         "model_output": model_output
-    })
+    }
+
+with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+    results = executor.map(extract_model_output, range(N_PROMPTS), final_benchmark)
 
 # Save to new JSON file
-with open("model_responses.json", "w") as f:
-    json.dump(results, f, indent=2)
+with open(RESPONSES_FILE, "w") as f:
+    json.dump(list(results), f, indent=2)
 
-print("Saved question, answer, and model_output to model_responses.json")
-
+print(f"Saved question, answer, and model_output to \"{os.path.relpath(RESPONSES_FILE, PROJECT_DIR)}\"")
+print(f"Saved output messages to \"{os.path.relpath(OUT_LOG, PROJECT_DIR)}\"")
+print(f"Saved error messages to \"{os.path.relpath(ERR_LOG, PROJECT_DIR)}\"")

--- a/test_model.py
+++ b/test_model.py
@@ -3,9 +3,11 @@ import json
 import os
 from openai import OpenAI
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict
+from typing import Any
 from threading import Lock
 from pathlib import Path
+from collections import defaultdict
+
 
 # Initialize client
 client = OpenAI(
@@ -13,46 +15,86 @@ client = OpenAI(
     api_key="sk",
 )
 
-# Load benchmark dataset (with question, answer, cot_prompt)
-with open("benchmark_dataset.json", "r") as f:
-    final_benchmark = json.load(f)
+
+METHODS = ["base", "react", "cot", "scope"]
+
+def load_datasets() -> tuple[int, dict[str, Any]]:
+    datasets = {}
+    for method in METHODS:
+        with open(f"{method}_benchmark_dataset.json", "r") as f:
+            datasets[method] = json.load(f)
+    # number of prompts to test for each method
+    n_prompts = min(map(len, datasets.values()))
+    return n_prompts, datasets
+
+N_PROMPTS, DATASETS = load_datasets()
+
+
+PROJECT_DIR = Path(__file__).parent
+
+def setup_log_files() -> tuple[dict[str, Path]]:
+    # Setup log directory
+    log_dir = PROJECT_DIR / "logs"
+    log_dir.mkdir(exist_ok=True, parents=True)
+
+    base = "model_responses"
+
+    out_log_files = list(map(lambda method: log_dir / f"{method}_{base}.out", METHODS))
+    err_log_files = list(map(lambda method: log_dir / f"{method}_{base}.err", METHODS))
+
+    # remove log files if they exist (we overwrite response files so dont need to be unlinked)
+    for out, err in zip(out_log_files, err_log_files):
+        try:
+            out.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            err.unlink()
+        except FileNotFoundError:
+            pass
+
+    return dict(zip(METHODS, out_log_files)), dict(zip(METHODS, err_log_files))
+
+OUT_LOG_FILES, ERR_LOG_FILES = setup_log_files()
+
+
+def setup_locks() -> tuple[Any]:
+    out_locks = {method: Lock() for method in METHODS}
+    err_locks = {method: Lock() for method in METHODS}
+
+    return out_locks, err_locks
+
+OUT_LOCKS, ERR_LOCKS = setup_locks()
+
 
 # Useful constants
 N_RETRIES = 2
 N_CORES = os.cpu_count() or 8
 N_WORKERS = N_CORES * 2
-N_PROMPTS = len(final_benchmark)
 
-PROJECT_DIR = Path(__file__).parent
 
-# Responses file
-RESPONSES_FILE = PROJECT_DIR / "model_responses.json"
-
-# Setup log directory/files
-LOG_DIR = PROJECT_DIR / "logs"
-LOG_DIR.mkdir(exist_ok=True, parents=True)
-
-OUT_LOG = LOG_DIR / "model_responses.out"
-ERR_LOG = LOG_DIR / "model_responses.err"
-
-try: # remove log files if they already exist
-    OUT_LOG.unlink()
-    ERR_LOG.unlink()
-except FileNotFoundError:
-    pass
-
-# Lock to prevent interleaving prints
-out_lock, err_lock = Lock(), Lock()
-def safe_out_log(*args: Any, **kwargs: Any) -> None:
-    with out_lock, open(OUT_LOG, "a") as out: # to stdout and out log
-        print(*args, **kwargs)
+def safe_out_log(method: str, *args: Any, **kwargs: Any) -> None:
+    with OUT_LOCKS[method], open(OUT_LOG_FILES[method], "a") as out: # to stdout and out_log
+        print(f"[{method.upper()}]", *args, **kwargs)
         print(*args, **kwargs, file=out)
 
-def safe_err_log(*args: Any, **kwargs: Any) -> None:
-    with err_lock, open(ERR_LOG, "a") as err:
+def safe_err_log(method: str, *args: Any, **kwargs: Any) -> None:
+    with ERR_LOCKS[method], open(ERR_LOG_FILES[method], "a") as err:
         print(*args, **kwargs, file=err)
 
-def extract_model_output(idx: int, item: Dict[str, Any]) -> Dict[str, Any]:
+
+def aggregate_benchmarks() -> tuple[list[Any], list[Any]]:
+    ids, aggregate_prompts = [], []
+    for method, prompts in DATASETS.items():
+        aggregate_prompts.extend(prompts)
+        # (prompt index (1-indexed) in resp. dataset, method string (e.g. "base", "scope", "cot", etc.))
+        ids.extend(zip(range(1, N_PROMPTS+1), [method] * N_PROMPTS))
+    return ids, aggregate_prompts
+
+
+def extract_model_output(id: tuple[int, str], item: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    idx, method = id
+
     messages = [
         {"role": "system", "content": "You are a helpful math assistant."},
         {"role": "user", "content": item["prompt"]}
@@ -72,32 +114,49 @@ def extract_model_output(idx: int, item: Dict[str, Any]) -> Dict[str, Any]:
             model_output = response.choices[0].message.content
             break  # success → exit loop
         except Exception as e:
-            err_msg = f"[ERROR] Prompt {idx+1}: {e}"
+            err_msg = f"[ERROR] Prompt {idx}: {e}"
             retries_left -= 1  # decrease retry counter
             if retries_left == -1:
                 model_output = "<answer> response failed </answer>"
-                safe_err_log(err_msg, f"Out of retries\n", sep="\n")
+                safe_err_log(method, err_msg, f"Out of retries\n", sep="\n")
                 break
             else:
-                safe_err_log(err_msg, f"Retrying... ({retries_left} retries left)\n", sep="\n")
+                safe_err_log(method, err_msg, f"Retrying... ({retries_left} retries left)\n", sep="\n")
     
-    safe_out_log(f"Prompt {idx+1}:", model_output, sep="\n", end="\n\n")
+    safe_out_log(method, f"Prompt {idx}:", model_output, sep="\n", end="\n\n")
 
-    return {
-        # compile simplified result entry
-        "category": item["category"],
-        "question": item["question"],
-        "answer": item["answer"],
-        "model_output": model_output
-    }
+    return (
+        method,
+        {
+            # simplified result entry
+            "category": item["category"],
+            "question": item["question"],
+            "answer": item["answer"],
+            "model_output": model_output
+        }
+    )
 
-with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
-    results = executor.map(extract_model_output, range(N_PROMPTS), final_benchmark)
 
-# Save to new JSON file
-with open(RESPONSES_FILE, "w") as f:
-    json.dump(list(results), f, indent=2)
+def group_results_by_method(aggregate_results: list[tuple[str, dict[str, Any]]]) -> dict[str, list[dict[str, Any]]]:
+    grouped_results = defaultdict(list)
+    for method, result_entry in aggregate_results:
+        grouped_results[method].append(result_entry)
+    return grouped_results
 
-print(f"Saved question, answer, and model_output to \"{os.path.relpath(RESPONSES_FILE, PROJECT_DIR)}\"")
-print(f"Saved output messages to \"{os.path.relpath(OUT_LOG, PROJECT_DIR)}\"")
-print(f"Saved error messages to \"{os.path.relpath(ERR_LOG, PROJECT_DIR)}\"")
+
+def compute_and_save_results() -> None:
+    ids, prompts = aggregate_benchmarks()
+    with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+        aggregate_results = executor.map(extract_model_output, ids, prompts)
+    grouped_results = group_results_by_method(aggregate_results)
+    for method, result_entries in grouped_results.items():
+        with open(PROJECT_DIR / f"{method}_model_responses.json", "w") as f:
+            json.dump(result_entries, f, indent=2)
+
+
+compute_and_save_results()
+
+
+print(f"Saved questions, answers, and model outputs to \"{{method_name}}_model_responses.json\"")
+print(f"Saved output messages to \"{{method_name}}_model_responses.out\"")
+print(f"Saved error messages to \"{{method_name}}_model_responses.err\"")

--- a/test_model.py
+++ b/test_model.py
@@ -1,6 +1,7 @@
 import re
 import json
 import os
+import sys
 import time
 from openai import OpenAI
 from concurrent.futures import ThreadPoolExecutor
@@ -17,36 +18,33 @@ client = OpenAI(
 )
 
 
-METHODS = ["base", "react", "cot", "scope"]
-
-def load_datasets() -> tuple[int, dict[str, Any]]:
+def load_datasets(config: dict[str, Any]) -> dict[str, Any]:
     datasets = {}
-    for method in METHODS:
+    for method in config["methods"]:
         with open(f"{method}_benchmark_dataset.json", "r") as f:
             datasets[method] = json.load(f)
+
     # number of prompts to test for each method
     n_prompts = min(map(len, datasets.values()))
-    return n_prompts, datasets
+    config["n_prompts"] = min(config["n_prompts"], n_prompts) # save to config
 
-N_PROMPTS, DATASETS = load_datasets()
+    return datasets
 
-
-PROJECT_DIR = Path(__file__).parent
 
 def ensure_dir(dir: str) -> Path:
-    path = PROJECT_DIR / dir
+    project_dir = Path(__file__).parent
+    path = project_dir / dir
     path.mkdir(exist_ok=True)
     return path
 
 
-def setup_log_files() -> tuple[dict[str, Path], dict[str, Path]]:
+def setup_log_files(config: dict[str, Any]) -> None:
     # Setup log directory
     log_dir = ensure_dir("logs")
 
     base = "model_responses"
-
-    out_log_files = list(map(lambda method: log_dir / f"{method}_{base}.out", METHODS))
-    err_log_files = list(map(lambda method: log_dir / f"{method}_{base}.err", METHODS))
+    out_log_files = list(map(lambda method: log_dir / f"{config["model"]}_{method}_{base}.out", config["methods"]))
+    err_log_files = list(map(lambda method: log_dir / f"{config["model"]}_{method}_{base}.err", config["methods"]))
 
     # remove log files if they exist (we overwrite response files so dont need to be unlinked)
     for out, err in zip(out_log_files, err_log_files):
@@ -59,88 +57,100 @@ def setup_log_files() -> tuple[dict[str, Path], dict[str, Path]]:
         except FileNotFoundError:
             pass
 
-    return dict(zip(METHODS, out_log_files)), dict(zip(METHODS, err_log_files))
-
-OUT_LOG_FILES, ERR_LOG_FILES = setup_log_files()
-
-
-def setup_locks() -> tuple[Any]:
-    out_locks = {method: Lock() for method in METHODS}
-    err_locks = {method: Lock() for method in METHODS}
-
-    return out_locks, err_locks
-
-OUT_LOCKS, ERR_LOCKS = setup_locks()
+    config.update({
+        "out_logs": dict(zip(config["methods"], out_log_files)),
+        "err_logs": dict(zip(config["methods"], err_log_files))
+    })
 
 
-# Useful constants
-N_RETRIES = 2
-N_CORES = os.cpu_count() or 8
-N_WORKERS = N_CORES * 2
+def setup_locks(config: dict[str, Any]) -> None:
+    console_lock = Lock()
+
+    out_locks = {method: Lock() for method in config["methods"]}
+    err_locks = {method: Lock() for method in config["methods"]}
+
+    config.update({
+        "cons_lock": console_lock,
+        "out_locks": out_locks,
+        "err_locks": err_locks
+    })
 
 
-def safe_out_log(method: str, *args: Any, **kwargs: Any) -> None:
-    with OUT_LOCKS[method], open(OUT_LOG_FILES[method], "a") as out: # to stdout and out_log
+def safe_out_log(config: dict[str, Any], method: str, *args: Any, **kwargs: Any) -> None:
+    with (
+        config["cons_lock"], 
+        config["out_locks"][method],
+        open(config["out_logs"][method], "a") as out
+    ): # to stdout and out_log
         print(f"[{method.upper()}]", *args, **kwargs)
         print(*args, **kwargs, file=out)
 
-def safe_err_log(method: str, *args: Any, **kwargs: Any) -> None:
-    with ERR_LOCKS[method], open(ERR_LOG_FILES[method], "a") as err:
+
+def safe_err_log(config: dict[str, Any], method: str, *args: Any, **kwargs: Any) -> None:
+    with (
+        config["err_locks"][method],
+        open(config["err_logs"][method], "a") as err
+    ):
         print(*args, **kwargs, file=err)
 
 
-def aggregate_benchmarks() -> tuple[list[Any], list[Any]]:
+def aggregate_benchmarks(config: dict[str, Any], datasets: dict[str, Any]) -> tuple[list[Any], list[Any]]:
     ids, aggregate_prompts = [], []
-    for method, prompts in DATASETS.items():
-        aggregate_prompts.extend(prompts[:N_PROMPTS])
+    for method, prompts in datasets.items():
+        aggregate_prompts.extend(prompts[:config["n_prompts"]])
         # (prompt index (1-indexed) in resp. dataset, method string (e.g. "base", "scope", "cot", etc.))
-        ids.extend(zip(range(1, N_PROMPTS+1), [method] * N_PROMPTS))
+        ids.extend(zip(range(1, config["n_prompts"]+1), [method] * config["n_prompts"]))
     return ids, aggregate_prompts
 
 
-def extract_model_output(id: tuple[int, str], item: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    idx, method = id
+def model_output_extractor(config: dict[str, Any]) -> Any:
+    def extract_model_output(id: tuple[int, str], item: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        idx, method = id
 
-    messages = [
-        {"role": "system", "content": "You are a helpful math assistant."},
-        {"role": "user", "content": item["prompt"]}
-    ]
+        messages = [
+            {"role": "system", "content": "You are a helpful math assistant."},
+            {"role": "user", "content": item["prompt"]}
+        ]
 
-    retries_left = N_RETRIES
-    while retries_left >= 0:
-        try:
-            # Call the v1/chat/completions endpoint
-            response = client.chat.completions.create(
-                model="tei",
-                messages=messages,
-                temperature=0.0,
-                max_tokens=8000
-            )
-            # Extract model output
-            model_output = response.choices[0].message.content
-            break  # success → exit loop
-        except Exception as e:
-            err_msg = f"[ERROR] Prompt {idx}: {e}"
-            retries_left -= 1  # decrease retry counter
-            if retries_left == -1:
-                model_output = "<answer> response failed </answer>"
-                safe_err_log(method, err_msg, f"Out of retries\n", sep="\n")
-                break
-            else:
-                safe_err_log(method, err_msg, f"Retrying... ({retries_left} retries left)\n", sep="\n")
-    
-    safe_out_log(method, f"Prompt {idx}:", model_output, sep="\n", end="\n\n")
+        retries_left = config["n_retries"]
+        while retries_left >= 0:
+            try:
+                # Call the v1/chat/completions endpoint
+                response = client.chat.completions.create(
+                    model=config["model"],
+                    messages=messages,
+                    temperature=0.0,
+                    max_tokens=8000
+                )
+                # Extract model output
+                model_output = response.choices[0].message.content
+                break  # success → exit loop
+            except Exception as e:
+                err_msg = f"[ERROR] Prompt {idx}: {e}"
+                retries_left -= 1  # decrease retry counter
+                if retries_left == -1:
+                    model_output = "<answer> response failed </answer>"
+                    safe_err_log(config, method, err_msg, f"Out of retries\n", sep="\n")
+                    break
+                else:
+                    safe_err_log(config, method, err_msg, f"Retrying... ({retries_left} retries left)\n", sep="\n")
+        
+        safe_out_log(config, method, f"Prompt {idx}:", model_output, sep="\n", end="\n\n")
 
-    return (
-        method,
-        {
-            # simplified result entry
-            "category": item["category"],
-            "question": item["question"],
-            "answer": item["answer"],
-            "model_output": model_output
-        }
-    )
+        return (
+            method,
+            {
+                # simplified result entry
+                "category": item["category"],
+                "question": item["question"],
+                "answer": item["answer"],
+                "model_output": model_output
+            }
+        )
+
+    # return a closure that captures model from outer scope for
+    # use in executor.map in compute_and_save_results()
+    return extract_model_output
 
 
 def group_results_by_method(aggregate_results: list[tuple[str, dict[str, Any]]]) -> dict[str, list[dict[str, Any]]]:
@@ -150,24 +160,123 @@ def group_results_by_method(aggregate_results: list[tuple[str, dict[str, Any]]])
     return grouped_results
 
 
-def compute_and_save_results() -> None:
-    ids, prompts = aggregate_benchmarks()
-    with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
-        aggregate_results = executor.map(extract_model_output, ids, prompts)
+def compute_and_save_results(config: dict[str, Any], datasets: dict[str, Any]) -> None:
+    ids, prompts = aggregate_benchmarks(config, datasets)
+    with ThreadPoolExecutor(max_workers=config["n_workers"]) as executor:
+        aggregate_results = executor.map(model_output_extractor(config), ids, prompts)
     grouped_results = group_results_by_method(aggregate_results)
     output_dir = ensure_dir("model_outputs")
     for method, result_entries in grouped_results.items():
-        with open(output_dir / f"{method}_model_responses.json", "w") as f:
+        with open(output_dir / f"{config["model"]}_{method}_model_responses.json", "w") as f:
             json.dump(result_entries, f, indent=2)
 
 
-if __name__ == "__main__":
+def print_usage() -> None:
+    usage = """
+USAGE:
+python3 test_model.py --model | -m {model} [--datasets | -d [b][r][c][s]] [--n-prompts | -n {n}] [--n-workers | -w {w}] [--n-retries | -r {r}]
+
+Configures script to run on {model} with the dataset flags (default: all) 
+specifying which benchmark datasets to use for generating model outputs;
+up to {n} (default: min(1000, min(map(len, datasets)))) prompts from each dataset are
+used, with up to {w} (default: (os.cpu_count() or 8) * 2) concurrent workers, and up to
+{r} (default: 0) retries on failure for each prompt.
+
+Dataset flags:
+    b => base benchmark dataset 
+    r => react benchmark dataset
+    c => cot benchmark dataset
+    s => scope benchmark dataset
+"""
+    print(usage)
+
+
+def parse_args() -> dict[str, Any]:
+    args = sys.argv[1:]
+    n_args = len(args)
+
+    aliases = {
+        "b": "base",
+        "r": "react",
+        "c": "cot",
+        "s": "scope",
+    }
+
+    config = {}
+
+    def finished_parsing(reqs: tuple[str, ...] = ("model",)) -> bool:
+        return all(req in config for req in reqs)
+
+    def apply_defaults(config: dict[str, Any]) -> None:
+        defaults = {
+            "methods": list(aliases.values()),
+            "n_workers": (os.cpu_count() or 8) * 2,
+            "n_retries": 0,
+            "n_prompts": 1000
+        }
+        config.update({
+            k: v
+            for k, v in defaults.items()
+            if k not in config
+        })
+
+    i = 0
+    while i < n_args - 1:
+        if args[i] in ("--model", "-m"):
+            config["model"] = args[i+1]
+        elif args[i] in ("--datasets", "-d"): 
+            matching = set(aliases.keys()).intersection(set(args[i+1]))
+            if (not matching or len(matching) != len(args[i+1])):
+                break # no/bad flag passed in
+            config["methods"] = list(map(lambda k: aliases[k], matching))
+        elif args[i] in ("--n-prompts", "-n"):
+            config["n_prompts"] = int(args[i+1])
+        elif args[i] in ("--n-workers", "-w"):
+            config["n_workers"] = int(args[i+1])
+        elif args[i] in ("--n-retries", "-r"):
+            config["n_retries"] = int(args[i+1])
+        else:
+            print(f"Unknown argument: {args[i]}")
+            print_usage()
+            exit(-1)
+        i += 2
+
+    apply_defaults(config)
+
+    if finished_parsing():
+        return config
+
+    print("Bad/missing arguments!")
+    print_usage()
+    exit(-1)
+
+
+def print_config(config: dict[str, Any], indent: str = " " * 4) -> None:
+    print("Running with the following configuration:")
+    print("{")
+    for k, v in config.items():
+        print(f"{indent}\"{k}\": {v}")
+    print("}\n\n")
+
+
+def main() -> None:
+    config = parse_args()
+    print_config(config) # for debugging
+
+    datasets = load_datasets(config)
+    setup_log_files(config)
+    setup_locks(config)
+
     start_time = time.perf_counter()
-    compute_and_save_results()
+    compute_and_save_results(config, datasets)
     duration = time.perf_counter() - start_time
 
-    print(f"\nTook {duration:.3f} seconds!\n")
+    print(f"\nSaved questions, answers, and model outputs to \"model_outputs/{{model}}_{{method}}_model_responses.json\"")
+    print(f"Saved output messages to \"logs/{{model}}_{{method}}_model_responses.out\"")
+    print(f"Saved error messages to \"logs/{{model}}_{{method}}_model_responses.err\"")
 
-    print(f"Saved questions, answers, and model outputs to \"model_outputs/{{method_name}}_model_responses.json\"")
-    print(f"Saved output messages to \"logs/{{method_name}}_model_responses.out\"")
-    print(f"Saved error messages to \"logs/{{method_name}}_model_responses.err\"")
+    print(f"\nCompleted in {duration:.3f} seconds!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pr is supposed to resolve issue #1.

Key changes:

- add cli for easy configuration (e.g. model, methods, num_workers, num_prompts, num_retries)

- add parallel benchmarking with ThreadPoolExecutor - **_achieved over a 15x speedup_**

- add support for benchmarking each of the "base", "react", "cot", "scope" datasets

Key notes:

- method denotes the prompting strategy, e.g. "base", "react", "cot", "scope"

- assumes that each dataset is located in the project root with format "{method}_benchmark_dataset.json" - can make quick update to pull benchmark dataset json files from a project subdirectory like "datasets/"

- saves model outputs for each method to "model_outputs/{method}_model_responses.json", relative to project root

Future improvements:

- further improve api request concurrency (possibly use the AsyncOpenAI client instead of OpenAI)